### PR TITLE
use weekdaysMin as weekday label

### DIFF
--- a/addons/web/static/src/js/views/calendar/calendar_model.js
+++ b/addons/web/static/src/js/views/calendar/calendar_model.js
@@ -458,7 +458,7 @@ return AbstractModel.extend({
             monthNames: moment.months(),
             monthNamesShort: moment.monthsShort(),
             dayNames: moment.weekdays(),
-            dayNamesShort: moment.weekdaysShort(),
+            dayNamesShort: moment.weekdaysMin(),
             firstDay: this.week_start,
             slotLabelFormat: _t.database.parameters.time_format.search("%H") !== -1 ? format24Hour : format12Hour,
             allDaySlot: this.mapping.all_day || this.fields[this.mapping.date_start].type === 'date',


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
use weekdaysMin as weekday label, otherwise all show "周“ for chinese

Current behavior before PR:
 show all "周“ for weekday label

![image](https://user-images.githubusercontent.com/1404460/121330459-9fc13600-c948-11eb-8911-32ebb24e38ae.png)

Desired behavior after PR is merged:

 show correct label, such as  日 一 二 三 四 五 六


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
